### PR TITLE
Fix error message for invalid InputObject type

### DIFF
--- a/src/Eryph.ClientRuntime.Configuration.Commands/NewEryphClientCredentialsCmdlet.cs
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/NewEryphClientCredentialsCmdlet.cs
@@ -60,7 +60,7 @@ namespace Eryph.ClientRuntime.Configuration
                     if (keyPair == null)
                     {
                         WriteError(new ErrorRecord(
-                            new InvalidOperationException("Invalid InputObject. InputObject has be a SecureString with private key or a PCKS8 private key string."),
+                            new InvalidOperationException("Invalid InputObject. InputObject has be a SecureString with private key or a PKCS1 private key string."),
                             $"EryphClientCredentials{ErrorCategory.InvalidArgument}", ErrorCategory.InvalidArgument, inputObject));
                         continue;
                     }


### PR DESCRIPTION
we expect a PKCS1 not a PKCS8 => https://stackoverflow.com/questions/20065304/differences-between-begin-rsa-private-key-and-begin-private-key