### PR TITLE
add support for session wide credentials

### DIFF
--- a/build/Eryph.ClientRuntime.Configuration.psd1
+++ b/build/Eryph.ClientRuntime.Configuration.psd1
@@ -80,7 +80,9 @@ CmdletsToExport = @(
     "Remove-EryphClientConfiguration",
     "New-EryphClientCredentials",
     "Get-EryphClientCredentials",
-    "Set-EryphConfigurationStore"
+    "Set-EryphConfigurationStore",
+    "Set-EryphSessionCredentials",
+    "Clear-EryphSessionCredentials"
 )
 
 # Variables to export from this module

--- a/src/Eryph.ClientRuntime.Configuration.Commands/ClearEryphSessionCredentialsCmdlet.cs
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/ClearEryphSessionCredentialsCmdlet.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+using JetBrains.Annotations;
+
+namespace Eryph.ClientRuntime.Configuration
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Clear, "EryphSessionCredentials")]
+    public class ClearEryphSessionCredentialsCmdlet : PSCmdlet
+    {
+        protected override void ProcessRecord()
+        {
+            var variable = SessionState.PSVariable.Get("EryphSessionCredentials");
+            if (variable != null)
+            {
+                SessionState.PSVariable.Remove("EryphSessionCredentials");
+                WriteVerbose("Session credentials cleared");
+            }
+            else
+            {
+                WriteVerbose("No session credentials were set");
+            }
+        }
+    }
+}

--- a/src/Eryph.ClientRuntime.Configuration.Commands/SetEryphSessionCredentialsCmdlet.cs
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/SetEryphSessionCredentialsCmdlet.cs
@@ -1,0 +1,21 @@
+using System.Management.Automation;
+using Eryph.IdentityModel.Clients;
+using JetBrains.Annotations;
+
+namespace Eryph.ClientRuntime.Configuration
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Set, "EryphSessionCredentials")]
+    public class SetEryphSessionCredentialsCmdlet : PSCmdlet
+    {
+        [Parameter(Mandatory = true, ValueFromPipeline = true)]
+        [ValidateNotNull]
+        public ClientCredentials Credentials { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            SessionState.PSVariable.Set("EryphSessionCredentials", Credentials);
+            WriteVerbose($"Session credentials set for client: {Credentials.Id}");
+        }
+    }
+}

--- a/src/Eryph.ClientRuntime.Powershell/EryphCmdLet.cs
+++ b/src/Eryph.ClientRuntime.Powershell/EryphCmdLet.cs
@@ -24,6 +24,8 @@ namespace Eryph.ClientRuntime.Powershell
             var clientCredentials = Credentials;
             if (clientCredentials != null) return clientCredentials;
 
+            if (SessionState.PSVariable.GetValue("EryphSessionCredentials") is ClientCredentials sessionCredentials)
+                return sessionCredentials;
 
             var lookup = new ClientCredentialsLookup(new PowershellEnvironment(SessionState));
             clientCredentials = lookup.FindCredentials();
@@ -31,7 +33,7 @@ namespace Eryph.ClientRuntime.Powershell
             if (clientCredentials == null)
             {
                 throw new InvalidOperationException(@"Could not find credentials for eryph.
-You can use the parameter Credentials to set the eryph credentials. If not set, the credentials will be searched in your local configuration. 
+You can use the parameter Credentials to set the eryph credentials. If not set, the credentials will be searched in your local configuration.
 If there is no default eryph client in your configuration the command will try to access the default system-client of a local running eryph zero or identity server.
 To access the system-client you will have to run this command as Administrator (Windows) or root (Linux).
 ");


### PR DESCRIPTION
It is currently not possible to set default credentials used accross commands in current powershell session.