### PR TITLE
Consume OpenIddict 7 client-assertion preview (Eryph.IdentityModel.Clients)

### DIFF
--- a/src/Eryph.ClientRuntime.Configuration/Eryph.ClientRuntime.Configuration.csproj
+++ b/src/Eryph.ClientRuntime.Configuration/Eryph.ClientRuntime.Configuration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.IdentityModel.Clients" Version="0.6.2-PullRequest0042.5" />
+    <PackageReference Include="Eryph.IdentityModel.Clients" Version="0.7.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Eryph.ClientRuntime.Configuration/Eryph.ClientRuntime.Configuration.csproj
+++ b/src/Eryph.ClientRuntime.Configuration/Eryph.ClientRuntime.Configuration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eryph.IdentityModel.Clients" Version="0.6.1" />
+    <PackageReference Include="Eryph.IdentityModel.Clients" Version="0.6.2-PullRequest0042.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps `Eryph.IdentityModel.Clients` to the preview build (`0.6.2-PullRequest0042.5`, dbosoft feed) that negotiates the client-assertion audience via discovery — see eryph-org/dotnet-identitymodel#42.

This flows the OpenIddict 7 auth change through `Eryph.ClientRuntime.Authentication` so it can be tested end-to-end (and consumed by dotnet-computeclient) against an upgraded eryph server. The `ClientCredentials` API is unchanged; the new behaviour (issuer audience + `client-authentication+jwt`, fail-closed on bad discovery) is internal.

Preview pin — to be re-pinned to the released `Eryph.IdentityModel.Clients` once dotnet-identitymodel#42 merges.